### PR TITLE
Support jax to tfjs conversion with dynamic models

### DIFF
--- a/maxim/models/maxim.py
+++ b/maxim/models/maxim.py
@@ -81,10 +81,18 @@ class UpSampleRatio(nn.Module):
   @nn.compact
   def __call__(self, x):
     n, h, w, c = x.shape
+    if self.ratio < 1:
+        ratio = int(1 / self.ratio)
+        h = h // ratio
+        w = w // ratio
+    else:
+        h = h * self.ratio
+        w = w * self.ratio
     x = jax.image.resize(
         x,
-        shape=(n, int(h * self.ratio), int(w * self.ratio), c),
-        method="bilinear")
+        shape=(n, h, w, c),
+        method="bilinear",
+    )
     x = Conv1x1(features=self.features, use_bias=self.use_bias)(x)
     return x
 


### PR DESCRIPTION
I'm converting the MAXIM models into Tensorflow.js models for use in Javascript.

When using fixed sizes, the model converts fine. However, using dynamic sizes (polymorphism) fails. For a discussion of why, [see here](https://github.com/google/jax/discussions/15995).

This PR adjusts the `UpSampleRatio` block to avoid the casting to `int`, which allows dynamically sized inputs (although inputs must still be a multiple of 64, which must be enforced outside of the model call).